### PR TITLE
Non-functional PR edits

### DIFF
--- a/MdeModulePkg/Core/Dxe/DxeMain.h
+++ b/MdeModulePkg/Core/Dxe/DxeMain.h
@@ -49,7 +49,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Protocol/SmmBase2.h>
 #include <Protocol/PeCoffImageEmulator.h>
 #include <Guid/MemoryTypeInformation.h>
-#include <Guid/MemoryTypeStatistics.h> // MU_CHANGE
+#include <Guid/MemoryTypeStatistics.h> // MU_CHANGE - Add MemoryBucketLib to MdeModulePkg
 #include <Guid/FirmwareFileSystem2.h>
 #include <Guid/FirmwareFileSystem3.h>
 #include <Guid/HobList.h>

--- a/MdeModulePkg/Core/Dxe/Mem/Page.c
+++ b/MdeModulePkg/Core/Dxe/Mem/Page.c
@@ -712,7 +712,7 @@ CoreAddMemoryDescriptor (
   for (Type = (EFI_MEMORY_TYPE)0; Type < EfiMaxMemoryType; Type++) {
     for (Index = 0; gMemoryTypeInformation[Index].Type != EfiMaxMemoryType; Index++) {
       if (Type == (EFI_MEMORY_TYPE)gMemoryTypeInformation[Index].Type) {
-        mMemoryTypeStatistics[Type].InformationIndex = (UINT32)Index;
+        mMemoryTypeStatistics[Type].InformationIndex = (UINT32)Index; // MU_CHANGE - Add MemoryBucketLib to MdeModulePkg
       }
     }
 

--- a/MdeModulePkg/Core/Pei/Memory/MemoryServices.c
+++ b/MdeModulePkg/Core/Pei/Memory/MemoryServices.c
@@ -589,16 +589,20 @@ PeiAllocatePages (
   OUT      EFI_PHYSICAL_ADDRESS  *Memory
   )
 {
-  EFI_STATUS                     Status;
-  PEI_CORE_INSTANCE              *PrivateData;
-  EFI_PEI_HOB_POINTERS           Hob;
-  EFI_PHYSICAL_ADDRESS           *FreeMemoryTop;
-  EFI_PHYSICAL_ADDRESS           *FreeMemoryBottom;
-  UINTN                          RemainingPages;
-  UINTN                          Granularity;
-  UINTN                          Padding;
+  EFI_STATUS            Status;
+  PEI_CORE_INSTANCE     *PrivateData;
+  EFI_PEI_HOB_POINTERS  Hob;
+  EFI_PHYSICAL_ADDRESS  *FreeMemoryTop;
+  EFI_PHYSICAL_ADDRESS  *FreeMemoryBottom;
+  UINTN                 RemainingPages;
+  UINTN                 Granularity;
+  UINTN                 Padding;
+
+  // MU_CHANGE [BEGIN] - Add MemoryBucketLib to MdeModulePkg
   EFI_HOB_GUID_TYPE              *MemBucketHob;
   PEI_MEMORY_BUCKET_INFORMATION  RuntimeBucketHob;
+
+  // MU_CHANGE [END] - Add MemoryBucketLib to MdeModulePkg
 
   if ((MemoryType != EfiLoaderCode) &&
       (MemoryType != EfiLoaderData) &&
@@ -652,8 +656,8 @@ PeiAllocatePages (
     FreeMemoryBottom = &(Hob.HandoffInformationTable->EfiFreeMemoryBottom);
   }
 
-  // MU_CHANGE START
-  MemBucketHob = GetFirstGuidHob (&gMemoryBucketInformationGuid);
+  // MU_CHANGE [BEGIN] - Add MemoryBucketLib to MdeModulePkg
+  MemBucketHob = GetFirstGuidHob (&gMemoryBucketInformationHobGuid);
   SyncMemoryBuckets (MemBucketHob);
 
   // Check if we're using the memory buckets
@@ -672,7 +676,7 @@ PeiAllocatePages (
     *FreeMemoryTop = GetBottomOfBucketsAddress ();
   }
 
-  // MU_CHANGE END
+  // MU_CHANGE [END] - Add MemoryBucketLib to MdeModulePkg
 
   //
   // Check to see if on correct boundary for the memory type.
@@ -737,7 +741,7 @@ PeiAllocatePages (
       MemoryType
       );
 
-    // MU_CHANGE START - Save memory allocations for the PEI memory buckets
+    // MU_CHANGE [BEGIN] - Add MemoryBucketLib to MdeModulePkg
     if (IsRuntimeType (MemoryType)) {
       UpdateCurrentBucketTop (*FreeMemoryTop, MemoryType);
 
@@ -757,7 +761,7 @@ PeiAllocatePages (
       InitializeRuntimeMemoryBuckets ();
     }
 
-    // MU_CHANGE END
+    // MU_CHANGE [END] - Add MemoryBucketLib to MdeModulePkg
 
     return EFI_SUCCESS;
   }

--- a/MdeModulePkg/Core/Pei/PeiMain.h
+++ b/MdeModulePkg/Core/Pei/PeiMain.h
@@ -43,7 +43,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <IndustryStandard/PeImage.h>
 #include <Library/PeiServicesTablePointerLib.h>
 #include <Library/MemoryAllocationLib.h>
-#include <Library/MemoryBucketLib.h>   // MU_CHANGE
+#include <Library/MemoryBucketLib.h>   // MU_CHANGE - Add MemoryBucketLib to MdeModulePkg
 #include <Library/TimerLib.h>          // MS_CHANGE
 #include <Guid/FirmwareFileSystem2.h>
 #include <Guid/FirmwareFileSystem3.h>

--- a/MdeModulePkg/Core/Pei/PeiMain.inf
+++ b/MdeModulePkg/Core/Pei/PeiMain.inf
@@ -62,7 +62,7 @@
   PeiCoreEntryPoint
   DebugLib
   MemoryAllocationLib
-  MemoryBucketLib                      ## MU_CHANGE - added runtime memory buckets in pei
+  MemoryBucketLib                      ## MU_CHANGE - Add MemoryBucketLib to MdeModulePkg
   CacheMaintenanceLib
   PeCoffLib
   PeiServicesTablePointerLib
@@ -82,7 +82,7 @@
   gEdkiiMigratedFvInfoGuid                      ## SOMETIMES_PRODUCES     ## HOB
   gEfiFirmwarePerformanceGuid # MS_CHANGE_161871 - needed to build SEC perf HOB
   gEfiDelayedDispatchTableGuid   # MSCHANGE
-  gMemoryBucketInformationGuid  # MU_CHANGE
+  gMemoryBucketInformationHobGuid  # MU_CHANGE - Add MemoryBucketLib to MdeModulePkg
 
 [Ppis]
   gEfiPeiStatusCodePpiGuid                      ## SOMETIMES_CONSUMES # PeiReportStatusService is not ready if this PPI doesn't exist

--- a/MdeModulePkg/Include/Guid/MemoryBucketInformation.h
+++ b/MdeModulePkg/Include/Guid/MemoryBucketInformation.h
@@ -1,22 +1,23 @@
 /** @file
+  Guids for PEI storing and retrieving the PEI memory buckets
+  as well as storing bucket information in DXE.
 
-Guids for Pei storing and retrieving the PEI memory buckets
-as well as storing bucket information in DXE.
+  Copyright (C) Microsoft Corporation. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
 
-Copyright (C) Microsoft Corporation. All rights reserved.
-SPDX-License-Identifier: BSD-2-Clause-Patent
+  MU_CHANGE [WHOLE FILE] - Add MemoryBucketLib to MdeModulePkg
 
 **/
 
-#ifndef _MEMORY_BUCKET_INFORMATION_H_
-#define _MEMORY_BUCKET_INFORMATION_H_
+#ifndef MEMORY_BUCKET_INFORMATION_H_
+#define MEMORY_BUCKET_INFORMATION_H_
 
 #include <Guid/MemoryTypeStatistics.h>
 
-#define MEMORY_BUCKET_INFORMATION_GUID \
+#define MEMORY_BUCKET_INFORMATION_HOB_GUID \
 { 0x36138737, 0xb6db, 0x4ed6, { 0x9b, 0x4b, 0xf9, 0x61, 0x28, 0xe7, 0x19, 0x3c } }
 
-extern EFI_GUID  gMemoryBucketInformationGuid;
+extern EFI_GUID  gMemoryBucketInformationHobGuid;
 
 // Current number of memory types being kept track of for the PEI memory buckets
 #define PEI_BUCKETS  4

--- a/MdeModulePkg/Include/Guid/MemoryTypeStatistics.h
+++ b/MdeModulePkg/Include/Guid/MemoryTypeStatistics.h
@@ -1,16 +1,16 @@
 /** @file
+  GUID and structure for storing memory type statistics.
+  Used for PEI and DXE memory buckets.
 
-GUID and structure for storing memory type statistics.
-Used for PEI and DXE memory buckets.
+  Copyright (C) Microsoft Corporation. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
 
-Copyright (C) Microsoft Corporation. All rights reserved.
-SPDX-License-Identifier: BSD-2-Clause-Patent
-
+  MU_CHANGE [WHOLE FILE] - Add MemoryBucketLib to MdeModulePkg
 
 **/
 
-#ifndef __MEMORY_TYPE_STATISTICS_GUID_H__
-#define __MEMORY_TYPE_STATISTICS_GUID_H__
+#ifndef MEMORY_TYPE_STATISTICS_GUID_H_
+#define MEMORY_TYPE_STATISTICS_GUID_H_
 
 #define MEMORY_TYPE_STATISTICS_GUID \
   { 0x6146C0D6, 0x8E30, 0x4DC2, { 0xA9, 0xCB, 0x5D, 0x85, 0x10, 0xC4, 0x8B, 0x39 }}

--- a/MdeModulePkg/Include/Library/MemoryBucketLib.h
+++ b/MdeModulePkg/Include/Library/MemoryBucketLib.h
@@ -1,16 +1,17 @@
 /** @file
+  Library for defining PEI memory buckets. This keeps track of the
+  different buckets and the data for the associated HOB.
+  For internal use only.
 
-Library for defining PEI memory buckets. This keeps track of the
-different buckets and the data for the associated HOB.
-For internal use only.
+  Copyright (C) Microsoft Corporation. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
 
-Copyright (C) Microsoft Corporation. All rights reserved.
-SPDX-License-Identifier: BSD-2-Clause-Patent
+  MU_CHANGE [WHOLE FILE] - Add MemoryBucketLib to MdeModulePkg
 
 **/
 
-#ifndef __MEMORY_BUCKET_LIB_H__
-#define __MEMORY_BUCKET_LIB_H__
+#ifndef MEMORY_BUCKET_LIB_H_
+#define MEMORY_BUCKET_LIB_H_
 
 #include <Uefi.h>
 #include <Base.h>

--- a/MdeModulePkg/Library/MemoryBucketLib/MemoryBucketLib.c
+++ b/MdeModulePkg/Library/MemoryBucketLib/MemoryBucketLib.c
@@ -1,10 +1,14 @@
 /**@file
-Library for defining PEI memory buckets. This keeps track of the
-different buckets and the data for the associated HOB.
-This library should not be called by anything outside of the PEI CORE.
+  Library for defining PEI memory buckets. This keeps track of the
+  different buckets and the data needed to populate a HOB passed to
+  DXE.
 
-Copyright (c) Microsoft Corporation.
-SPDX-License-Identifier: BSD-2-Clause-Patent
+  This library should not be called by anything outside of the PEI CORE.
+
+  MU_CHANGE [WHOLE FILE] - Add MemoryBucketLib to MdeModulePkg
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
 #include <PiPei.h>
@@ -419,7 +423,7 @@ BuildRuntimeMemoryAllocationInfoHob (
   )
 {
   BuildGuidDataHob (
-    &gMemoryBucketInformationGuid,
+    &gMemoryBucketInformationHobGuid,
     &mRuntimeBucketHob,
     (sizeof (PEI_MEMORY_BUCKET_INFORMATION))
     );

--- a/MdeModulePkg/Library/MemoryBucketLib/MemoryBucketLib.inf
+++ b/MdeModulePkg/Library/MemoryBucketLib/MemoryBucketLib.inf
@@ -1,5 +1,7 @@
 ## @file
-# Library that creates and manages Runtime memory buckets for use during PEI
+# Library that creates and manages runtime memory buckets for use during PEI
+#
+# MU_CHANGE [WHOLE FILE] - Add MemoryBucketLib to MdeModulePkg
 #
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: BSD-2-Clause-Patent

--- a/MdeModulePkg/Library/MemoryBucketLib/Readme.md
+++ b/MdeModulePkg/Library/MemoryBucketLib/Readme.md
@@ -1,20 +1,36 @@
-# Pei Memory Buckets
+# PEI Memory Buckets
 
-Pei memory buckets consolidate Pei memory allocations to be contiguous to reduce fragmentation of the
-memory map and is only used by the Pei Core.  Currently this is only used for EfiRuntimeServicesCode
-EfiRuntimeServicesData, EfiACPIReclaimMemory and EfiACPIMemoryNVS but additional memory types can
-be added.
+A memory bucket is a dedicated range of memory for a specific type of memory (e.g. code or data) that persists over
+the lifespan of system operation (e.g. boot or runtime). These properties allow memory management components throughout
+the boot to apply specific attributes to the memory for hardware and software enforcement of functional and security
+behavior.
 
-New Fixed PCDs were added to set the number of pages for each memory type that are currently used.
-The relevant PCDs are PcdPeiMemoryBucketRuntimeCode, PcdPeiMemoryBucketRuntimeData, PcdPeiMemoryBucketAcpiReclaimMemory
-and PcdPeiMemoryBucketAcpiMemoryNvs.
+Due to a number of technologies moving earlier into the boot flow, memory buckets that are allocated in PEI may now
+persist into OS runtime. This is the case for launch Standalone MM in PEI for example. As-is, the DXE Core is unaware
+of these bucket allocations so they are ultimately disjoint with equivalent bucket types allocated in DXE.
 
-## How to enable Pei Memory Buckets
+PEI memory buckets consolidate PEI memory allocations to be contiguous to reduce fragmentation of the memory map.
 
-All the added PCDs have a default value of 0 and if their values remain unedited then PEI memory buckets will not be
-used and memory allocation will be the same as before.  Setting any of these values to be non-zero will have you using
-the memory bucket infrastructure.  If you have any of these values set as a non-zero value and no PEI allocations for
-the relevant memory types are made then no memory bucket structures will be allocated or used.
+This feature is controlled via the following PCDs:
+
+- PcdPeiMemoryBucketRuntimeCode
+- PcdPeiMemoryBucketRuntimeData
+- PcdPeiMemoryBucketAcpiReclaimMemory
+- PcdPeiMemoryBucketAcpiMemoryNvs
+
+Platforms that do not allocate memory persistent into runtime do not need to perform integration for this capability
+as the default PCD values (`0`) will disable production of the PEI memory bucket HOB exposed to DXE. The functionality
+to read the PCDs and produce the HOB is contained within a library called `MemoryBucketLib` that is linked to PEI Core.
+
+Because `MemoryBucketLib` is a library class dependency on `PeiMain`, the instance must be specified in a platform
+DSC regardless of whether its functionality will be activated (via non-zero PCD values).
+
+## How to enable PEI Memory Buckets
+
+Set the PCDs listed in the previous section to a non-zero value.
+
+> If you have any of these values set as a non-zero value and no PEI allocations for
+> the relevant memory types are made then no memory bucket structures will be allocated or used.
 
 Be aware that the memory bucket sizes should be tuned match the number of pages each memory type uses in PEI to be the
-most space efficient.  
+most space efficient.

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -221,10 +221,12 @@
   #                dynamically.
   #
   MemoryBinOverrideLib|Include/Library/MemoryBinOverrideLib.h
-  # MU_CHANGE - Add MemoryBucketLib to MdeModulePkg
-  ## @libraryclass Keeps track of Runtime memory buckets during Pei
+
+  # MU_CHANGE [BEGIN] - Add MemoryBucketLib to MdeModulePkg
+  ## @libraryclass Keeps track of Runtime memory buckets during PEI
   #
   MemoryBucketLib|Include/Library/MemoryBucketLib.h
+  # MU_CHANGE [END] - Add MemoryBucketLib to MdeModulePkg
 
 [Guids]
   ## MdeModule package token space guid
@@ -549,11 +551,11 @@
 
   ## GUID used for Boot Discovery Policy FormSet guid and related variables.
   gBootDiscoveryPolicyMgrFormsetGuid = { 0x5b6f7107, 0xbb3c, 0x4660, { 0x92, 0xcd, 0x54, 0x26, 0x90, 0x28, 0x0b, 0xbd } }
-  ## MU_CHANGE
-  ## PEI memory buckets Guid.  Used to create and fetch the PEI memory buckets.
-  #
-  # Include/Guid/MemoryBucketInformation.h
-  gMemoryBucketInformationGuid = { 0x36138737, 0xb6db, 0x4ed6, { 0x9b, 0x4b, 0xf9, 0x61, 0x28, 0xe7, 0x19, 0x3c }}
+
+  # MU_CHANGE [BEGIN] - Add MemoryBucketLib to MdeModulePkg
+  ## Include/Guid/MemoryBucketInformation.h
+  gMemoryBucketInformationHobGuid = { 0x36138737, 0xb6db, 0x4ed6, { 0x9b, 0x4b, 0xf9, 0x61, 0x28, 0xe7, 0x19, 0x3c }}
+  # MU_CHANGE [END] - Add MemoryBucketLib to MdeModulePkg
 
 [Ppis]
   ## Include/Ppi/AtaController.h

--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -116,7 +116,6 @@
   ExceptionPersistenceLib|MdeModulePkg/Library/BaseExceptionPersistenceLibNull/BaseExceptionPersistenceLibNull.inf # MU_CHANGE
 
   MmuLib|MdePkg/Library/BaseMmuLibNull/BaseMmuLibNull.inf       ## MU_CHANGE
-  MemoryBucketLib|MdeModulePkg/Library/MemoryBucketLib/MemoryBucketLib.inf  ## MU_CHANGE
 
 # MU_CHANGE START Include MemoryProtectionHobLib
 [LibraryClasses.common.DXE_DRIVER, LibraryClasses.common.DXE_CORE, LibraryClasses.common.UEFI_APPLICATION]
@@ -149,6 +148,7 @@
 [LibraryClasses.common.PEI_CORE]
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf
   MemoryAllocationLib|MdePkg/Library/PeiMemoryAllocationLib/PeiMemoryAllocationLib.inf
+  MemoryBucketLib|MdeModulePkg/Library/MemoryBucketLib/MemoryBucketLib.inf  # MU_CHANGE - Add MemoryBucketLib to MdeModulePkg
 
 [LibraryClasses.common.PEIM]
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf
@@ -533,7 +533,7 @@
   MdeModulePkg/Library/PcdDatabaseLoaderLib/Dxe/PcdDatabaseLoaderLibDxe.inf   # MU_CHANGE
   MdeModulePkg/Library/MemoryBinOverrideLibNull/MemoryBinOverrideLibNull.inf  # MU_CHANGE
 
-  MdeModulePkg/Library/MemoryBucketLib/MemoryBucketLib.inf  ## MU_CHANGE
+  MdeModulePkg/Library/MemoryBucketLib/MemoryBucketLib.inf  # MU_CHANGE - Add MemoryBucketLib to MdeModulePkg
 
 # MU_CHANGE START
 !if $(TOOLCHAIN) != VS2017 and $(TOOLCHAIN) != VS2019


### PR DESCRIPTION
At a high-level:

1. `gMemoryBucketInformationGuid` -> `gMemoryBucketInformationHobGuid`
2. Move `MemoryBucketLib` instance in MdeModulePkg.dsc to `PEI_CORE` section
3. Update / make `MU_CHANGE` tags consistent throughout file modifications
4. Refactor MdeModulePkg/Library/MemoryBucketLib/Readme.md

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>